### PR TITLE
Refine Vans landing page styling and layout

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/componentes/InicioVans/InicioVans.jsx
+++ b/app/componentes/InicioVans/InicioVans.jsx
@@ -1,21 +1,21 @@
+import Cabecalho from "./cabecalho/Cabecalho";
+import "./iniciovans.css";
 
-import Cabecalho from './cabecalho/Cabecalho'
-import './iniciovans.css'
-
-export default function InicioVans(){
-    return(
-        <div className='inicio'>
-            <Cabecalho/>
-
-            <div className='mensagem'>
-                <h1>VANS IS OLD SKOOL</h1>
-                <p>
-                    A Vans é líder em moda com <br/>
-                    calçados e acessórios de alta <br/>
-                    qualidade e estilo autêntico.
-                </p>
-                <button>COMPRE AGORA</button>
-            </div>
-        </div>
-    )
+export default function InicioVans() {
+  return (
+    <section className="hero">
+      <div className="hero__overlay" aria-hidden="true" />
+      <Cabecalho />
+      <div className="hero__content">
+        <h1 className="hero__title">Vans is Old Skool</h1>
+        <p className="hero__description">
+          A Vans é referência em lifestyle, com calçados e acessórios cheios de
+          autenticidade para te acompanhar em qualquer rolê.
+        </p>
+        <a className="hero__cta" href="#produtos">
+          Compre agora
+        </a>
+      </div>
+    </section>
+  );
 }

--- a/app/componentes/InicioVans/cabecalho/Cabecalho.jsx
+++ b/app/componentes/InicioVans/cabecalho/Cabecalho.jsx
@@ -1,105 +1,116 @@
-'use client';
-import { useEffect } from 'react';
-import './cabecalho.css'
+"use client";
 
-export default function Cabecalho(){
-    useEffect(() => {
-        const menu = document.querySelector(".menu-toggle");
-        const cabecalho = document.querySelector(".cabecalho");
-    
-        if (window.innerWidth <= 768) {
-            cabecalho.classList.add("mobile");
-        }
-    
-        // menu.addEventListener("click", () => {
-        //     sidebar.classList.toggle("collapsed");
-        // });
-    }, []);
-    
+import { useMemo, useState } from "react";
+import "./cabecalho.css";
 
-    return(
-        <div className='cabecalho'>
-                    <div className='pesquisa'>
-                        <div className='logo'></div>
-                        <input type="search" className='search' placeholder="Old Skooll..."/>
-                        <select>
-                            <option>MAIS</option>
-                            <option>CALÇAS</option>
-                            <option>BLUSAS</option>
-                            <option>TENIS</option>
-                        </select>
-                        <a href="#" className='Ajuda'>AJUDA</a>
-                        <a href="#" className='Lojas'>LOJAS</a>
-                        <a href="#" className='Conta'>CONTA</a>
-                    </div>
+const navigationSections = [
+  {
+    label: "Web",
+    links: ["Aplicativo", "Contato", "Lojas físicas"],
+  },
+  {
+    label: "Novidades",
+    links: ["Blusas", "Calças", "Tênis", "Conjuntos"],
+  },
+  {
+    label: "Kids",
+    links: ["Tênis", "Brindes", "Prêmios"],
+  },
+  {
+    label: "Feminino",
+    links: ["Blusas", "Calças", "Tênis", "Vestidos"],
+  },
+  {
+    label: "Masculino",
+    links: ["Blusas", "Calças", "Tênis", "Jaquetas"],
+  },
+  {
+    label: "Latest",
+    links: ["Contratos", "Funcionários", "Lojas"],
+  },
+  {
+    label: "Sale",
+    links: ["Contratos", "Peças", "Lojas"],
+  },
+];
 
-                    <ul className="opcoes">
-                        <li className="dropdown" id="Web">
-                            <span>WEB</span>
-                            <div className="dropdown-content">
-                                <a href="#">Aplicativo</a><br />
-                                <a href="#">Contato</a><br />
-                                <a href="#">Lojas Fisicas</a>
-                            </div>
-                        </li>
+export default function Cabecalho() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-                        <li className="dropdown" id="Novidades">
-                            <span>NOVIDADES</span>
-                            <div className="dropdown-content">
-                                <a href="#">Blusas</a><br />
-                                <a href="#">Calças</a><br />
-                                <a href="#">Tenis</a><br />
-                                <a href="#">Conjutos</a>
-                            </div>
-                        </li>
+  const quickActions = useMemo(
+    () => [
+      { label: "Ajuda", href: "#" },
+      { label: "Lojas", href: "#" },
+      { label: "Conta", href: "#" },
+    ],
+    []
+  );
 
-                        <li className="dropdown" id="Kids">
-                            <span>KIDS</span>
-                            <div className="dropdown-content">
-                                <a href="#">Tenis</a><br />
-                                <a href="#">Brindes</a><br />
-                                <a href="#">Premios</a>
-                            </div>
-                        </li>
+  const handleToggleMenu = () => {
+    setIsMenuOpen((state) => !state);
+  };
 
-                        <li className="dropdown" id="Feminino">
-                            <span>FEMININO</span>
-                            <div className="dropdown-content">
-                                <a href="#">Blusas</a><br />
-                                <a href="#">Calças</a><br />
-                                <a href="#">Tenis</a><br />
-                                <a href="#">Vestidos</a>
-                            </div>
-                        </li>
+  return (
+    <header className={`cabecalho ${isMenuOpen ? "cabecalho--menu-aberto" : ""}`}>
+      <div className="cabecalho__topo">
+        <a className="cabecalho__logo" href="#" aria-label="Página inicial Vans" />
+        <label className="cabecalho__campo-busca">
+          <span className="sr-only">Buscar produtos</span>
+          <input
+            className="cabecalho__input"
+            type="search"
+            placeholder="Buscar Old Skool..."
+            spellCheck={false}
+            aria-label="Buscar produtos"
+          />
+        </label>
+        <select className="cabecalho__select" aria-label="Filtrar categoria">
+          <option value="mais">Mais</option>
+          <option value="calcas">Calças</option>
+          <option value="blusas">Blusas</option>
+          <option value="tenis">Tênis</option>
+        </select>
+        <nav className="cabecalho__links-rapidos" aria-label="Acesso rápido">
+          {quickActions.map(({ label, href }) => (
+            <a key={label} href={href}>
+              {label}
+            </a>
+          ))}
+        </nav>
+        <button
+          type="button"
+          className="cabecalho__menu-toggle"
+          onClick={handleToggleMenu}
+          aria-expanded={isMenuOpen}
+          aria-controls="navegacao-principal"
+        >
+          <span aria-hidden="true">{isMenuOpen ? "✕" : "☰"}</span>
+          <span className="sr-only">
+            {isMenuOpen ? "Fechar menu" : "Abrir menu"}
+          </span>
+        </button>
+      </div>
 
-                        <li className="dropdown" id="Masculino">
-                            <span>MASCULINO</span>
-                            <div className="dropdown-content">
-                                <a href="#">Blusas</a><br />
-                                <a href="#">Calças</a><br />
-                                <a href="#">Tenis</a><br />
-                                <a href="#">Jaquetas</a>
-                            </div>
-                        </li>
-
-                        <li className="dropdown" id="Latest">
-                            <span>LATEST</span>
-                            <div className="dropdown-content">
-                                <a href="#">Contratos</a><br />
-                                <a href="#">Funcionarios</a><br />
-                                <a href="#">Lojas</a>
-                            </div>
-                        </li>
-
-                        <li className="dropdown" id="Sale">
-                            <span>SALE</span>
-                            <div className="dropdown-content">
-                                <a href="#">Contratos</a><br />
-                                <a href="#">Peças</a><br />
-                                <a href="#">Lojas</a>
-                            </div>
-                        </li>
-                    </ul>
-        </div>
-    )
+      <nav
+        id="navegacao-principal"
+        className="cabecalho__navegacao"
+        aria-label="Navegação principal"
+      >
+        <ul className="cabecalho__lista">
+          {navigationSections.map(({ label, links }) => (
+            <li key={label} className="cabecalho__item">
+              <span className="cabecalho__item-label">{label}</span>
+              <div className="cabecalho__dropdown">
+                {links.map((link) => (
+                  <a key={link} href="#">
+                    {link}
+                  </a>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  );
 }

--- a/app/componentes/InicioVans/cabecalho/cabecalho.css
+++ b/app/componentes/InicioVans/cabecalho/cabecalho.css
@@ -1,149 +1,216 @@
 .cabecalho {
-    width: 75%;
-    margin: auto;
+  position: relative;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  color: #ffffff;
+  z-index: 2;
 }
 
-.cabecalho .pesquisa  {    
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    align-items: center;
+.cabecalho__topo {
+  display: grid;
+  align-items: center;
+  grid-template-columns: auto minmax(180px, 1fr) auto auto auto;
+  gap: 1rem;
+  padding: 1rem 0;
 }
 
-.cabecalho .pesquisa > *:not(.logo) {
-    background-color: transparent;
-    border: transparent;
-    margin: 10px 5px;
+.cabecalho__logo {
+  display: block;
+  width: clamp(120px, 18vw, 160px);
+  aspect-ratio: 3.6 / 1;
+  background: url("./VansLogo.png") center / contain no-repeat;
 }
 
-.cabecalho .pesquisa .logo {
-    min-width: 120px;
-    min-height: 50px;
-    background: url("./VansLogo.png") no-repeat center / cover;
+.cabecalho__campo-busca {
+  position: relative;
+  width: 100%;
 }
 
-.cabecalho .pesquisa select option {
-    color: black;
+.cabecalho__input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  backdrop-filter: blur(8px);
 }
 
-.cabecalho .pesquisa a {
-    text-decoration: none;
+.cabecalho__input::placeholder {
+  color: rgba(255, 255, 255, 0.65);
 }
 
-.cabecalho .pesquisa .tracoBord {
-    width: 80px;
-    height: 50px;
-    border-left: 2px solid lightgray;
+.cabecalho__select {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
 }
 
-.cabecalho .opcoes {
-    height: 50px;
-    width: 100%;
-    box-sizing: content-box;
-    border-top: 2px solid lightgray;
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-around;
+.cabecalho__select option {
+  color: #111111;
 }
 
-.cabecalho .opcoes .dropdown {
-    position: relative;
-    margin: 10px 5px;
+.cabecalho__links-rapidos {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
-.cabecalho .opcoes .dropdown .dropdown-content{
+.cabecalho__links-rapidos a {
+  text-decoration: none;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--duracao-transicao) ease,
+    color var(--duracao-transicao) ease;
+}
+
+.cabecalho__links-rapidos a:hover,
+.cabecalho__links-rapidos a:focus-visible {
+  border-color: rgba(255, 255, 255, 0.8);
+}
+
+.cabecalho__menu-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.cabecalho__menu-toggle:hover,
+.cabecalho__menu-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.cabecalho__navegacao {
+  margin-top: 0.75rem;
+}
+
+.cabecalho__lista {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  list-style: none;
+  padding: 0;
+}
+
+.cabecalho__item {
+  position: relative;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.cabecalho__item-label {
+  display: inline-block;
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid transparent;
+  transition: border-color var(--duracao-transicao) ease;
+}
+
+.cabecalho__item:hover .cabecalho__item-label,
+.cabecalho__item:focus-within .cabecalho__item-label {
+  border-color: rgba(255, 255, 255, 0.8);
+}
+
+.cabecalho__dropdown {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.6rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 180px;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.82);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: opacity var(--duracao-transicao) ease,
+    transform var(--duracao-transicao) ease;
+}
+
+.cabecalho__dropdown a {
+  color: rgba(255, 255, 255, 0.86);
+  text-decoration: none;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.cabecalho__item:hover .cabecalho__dropdown,
+.cabecalho__item:focus-within .cabecalho__dropdown {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+@media (max-width: 1024px) {
+  .cabecalho__topo {
+    grid-template-columns: auto 1fr auto auto;
+  }
+
+  .cabecalho__links-rapidos {
     display: none;
-    padding: 10px;
-    background-color: white;
-    border-radius: 5px;
-    position: absolute;
-    z-index: 1;
+  }
 }
 
-.cabecalho .opcoes .dropdown:hover .dropdown-content{
+@media (max-width: 768px) {
+  .cabecalho {
+    width: 100%;
+  }
+
+  .cabecalho__topo {
+    grid-template-columns: auto 1fr auto;
+  }
+
+  .cabecalho__select {
+    display: none;
+  }
+
+  .cabecalho__menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .cabecalho__navegacao {
+    display: none;
+    margin-top: 1.5rem;
+    background: rgba(0, 0, 0, 0.65);
+    border-radius: 1.25rem;
+    padding: 1.25rem;
+    backdrop-filter: blur(6px);
+  }
+
+  .cabecalho--menu-aberto .cabecalho__navegacao {
     display: block;
-}
+  }
 
-.cabecalho .opcoes .dropdown .dropdown-content a {
-    color: black;
-    text-decoration: none;
-    text-shadow: none;
-}
+  .cabecalho__lista {
+    flex-direction: column;
+    gap: 1rem;
+  }
 
-@media(max-width: 768px){
-    .cabecalho {
-        width: 100%;
-        height: 20%;
-        display: flex;
-    }
-    
-    .cabecalho .pesquisa > *:not(.logo,.search) {
-        background-color: transparent;
-        border: transparent;
-        display: none;
-    }
-    .search {
-        width: 50%;
-        height: 80%;
-    }
-    
-    .cabecalho .pesquisa .logo {
-        width: 100px;
-        height: 20px;
-        background: url("./VansLogo.png") no-repeat center / cover;
-    }
-    
-    .cabecalho .pesquisa select option {
-        color: black;
-    }
-    
-    .cabecalho .pesquisa a {
-        text-decoration: none;
-    }
-    
-    .cabecalho .pesquisa .tracoBord {
-        width: 80px;
-        height: 50px;
-        border-left: 2px solid lightgray;
-    }
-    
-    .cabecalho .opcoes {
-        height: 50px;
-        width: 100%;
-        box-sizing: content-box;
-        border-top: 2px solid lightgray;
-        list-style: none;
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: space-around;
-        display: none;
-    }
-    
-    .cabecalho .opcoes .dropdown {
-        position: relative;
-        margin: 10px 5px;
-    }
-    
-    .cabecalho .opcoes .dropdown .dropdown-content{
-        display: none;
-        padding: 10px;
-        background-color: white;
-        border-radius: 5px;
-        position: absolute;
-        z-index: 1;
-    }
-    
-    .cabecalho .opcoes .dropdown:hover .dropdown-content{
-        display: block;
-    }
-    
-    .cabecalho .opcoes .dropdown .dropdown-content a {
-        color: black;
-        text-decoration: none;
-        text-shadow: none;
-    }
+  .cabecalho__dropdown {
+    position: static;
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    box-shadow: none;
+    background: transparent;
+    padding: 0.75rem 0 0.25rem;
+  }
+
+  .cabecalho__dropdown a {
+    color: rgba(255, 255, 255, 0.85);
+  }
 }

--- a/app/componentes/InicioVans/iniciovans.css
+++ b/app/componentes/InicioVans/iniciovans.css
@@ -1,83 +1,81 @@
-.inicio {
-    min-width: 400px;
-    min-height: 400px;
-    width: 100vw;
-    height: 100vh;
-    position: relative;
-    background: url("./VansFundo.jpg") no-repeat center / cover;
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: clamp(520px, 85vh, 760px);
+  padding: 2.5rem clamp(1.5rem, 5vw, 6rem) 4rem;
+  color: #ffffff;
+  background: url("./VansFundo.jpg") center / cover no-repeat;
+  overflow: hidden;
 }
 
-.inicio * {
-    color: white;
-    text-shadow: black 0.1em 0.1em 0.2em;
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.35));
+  mix-blend-mode: multiply;
 }
 
-.inicio .mensagem {
-    margin: 12% 0 0 25%;
+.hero > *:not(.hero__overlay) {
+  position: relative;
+  z-index: 1;
 }
 
-.inicio .mensagem p {
-    margin: 20px 0;
+.hero__content {
+  max-width: min(540px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: clamp(2rem, 10vh, 6rem);
 }
 
-.inicio .mensagem button {
-    padding: 10px;
-    border: none;
-    background-color: darkred;
-    cursor: pointer; /* Adiciona cursor de mão para indicar interatividade */
-    transition: background-color 0.3s ease, transform 0.3s ease; /* Transição suave */
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  text-shadow: 0 12px 35px rgba(0, 0, 0, 0.45);
 }
 
-/* Efeito de Hover no Botão */
-.inicio .mensagem button:hover {
-    background-color: crimson; /* Altera a cor de fundo quando o mouse passa sobre */
-    transform: scale(1.1); /* Aumenta o botão em 10% */
+.hero__description {
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 8px 25px rgba(0, 0, 0, 0.45);
 }
 
-.inicio .mensagem button:active {
-    transform: scale(1); /* Reseta o zoom quando o botão é pressionado */
+.hero__cta {
+  align-self: flex-start;
+  padding: 0.85rem 2.75rem;
+  border-radius: 999px;
+  background: var(--cor-acento);
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform var(--duracao-transicao) ease,
+    background-color var(--duracao-transicao) ease;
 }
-@media(max-width: 768px){
-    .inicio {
-        min-width: 100%;
-        min-height: 30%;
-        width: 10vw;
-        height: 10vh;
-        position: relative;
-        background: url("./VansFundo.jpg") no-repeat center / cover;
-    }
-    
-    .inicio * {
-        color: white;
-        text-shadow: black 0.1em 0.1em 0.2em;
-    }
-    
-    .inicio .mensagem {
-        margin: 12% 0 0 25%;
-        display: none;
-    }
-    
-    .inicio .mensagem p {
-        margin: 20px 0;
-        display: none;
-    }
-    
-    .inicio .mensagem button {
-        padding: 10px;
-        border: none;
-        background-color: darkred;
-        cursor: pointer; /* Adiciona cursor de mão para indicar interatividade */
-        transition: background-color 0.3s ease, transform 0.3s ease; /* Transição suave */
-        display: none;
-    }
-    
-    /* Efeito de Hover no Botão */
-    .inicio .mensagem button:hover {
-        background-color: crimson; /* Altera a cor de fundo quando o mouse passa sobre */
-        transform: scale(1.1); /* Aumenta o botão em 10% */
-    }
-    
-    .inicio .mensagem button:active {
-        transform: scale(1); /* Reseta o zoom quando o botão é pressionado */
-    }
+
+.hero__cta:hover,
+.hero__cta:focus-visible {
+  background: var(--cor-acento-escuro);
+  transform: translateY(-2px);
+}
+
+.hero__cta:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    min-height: 560px;
+    padding: 1.5rem clamp(1rem, 5vw, 3rem) 3rem;
+    justify-content: flex-start;
+  }
+
+  .hero__content {
+    margin-top: 3rem;
+  }
 }

--- a/app/componentes/produtos/Produtos.jsx
+++ b/app/componentes/produtos/Produtos.jsx
@@ -1,32 +1,51 @@
+import ProdutosPequenos from "./produtoPequeno/ProdutosPequenos";
+import ProdutosGrandes from "./produtoGrande/ProdutosGrandes";
+import ProdutosMedios from "./produtoMedio/ProdutosMedios";
+import "./produtos.css";
 
-import './produtoPequeno/produtospequenos.css'
-import ProdutosPequenos from './produtoPequeno/ProdutosPequenos'
+const smallProducts = [
+  { id: "sapato1", name: "Sapatênis branco", price: 149.99 },
+  { id: "sapato2", name: "Sapato branco", price: 154.99 },
+  { id: "sapato3", name: "Sapato marrom claro", price: 130.0 },
+  { id: "sapato4", name: "Sapato marrom escuro", price: 140.0 },
+  { id: "sapato5", name: "Tênis azul acinzentado", price: 119.99 },
+  { id: "paisagem1", name: "Acampamento no campo", price: 730.0 },
+  { id: "paisagem2", name: "Viagem para a praia no Havaí", price: 2300.0 },
+  { id: "paisagem3", name: "Trilha no campo e na floresta", price: 250.0 },
+];
 
-import './produtoMedio/produtosmedios.css'
-import ProdutosMedios from './produtoMedio/ProdutosMedios'
+const mediumProducts = [
+  { id: "skatista", highlights: ["Novo", "Estilo", "Skates"] },
+  { id: "sapato", highlights: ["Uniforme", "Amigável", "Fashion"] },
+];
 
-import './produtoGrande/produtosgrandes.css'
-import ProdutosGrandes from './produtoGrande/ProdutosGrandes'
+export default function Produtos() {
+  return (
+    <section className="produtos" id="produtos">
+      <div className="produtos__cabecalho">
+        <span className="produtos__etiqueta">Produtos em destaque</span>
+        <h2 className="produtos__titulo">Encontre o par perfeito para cada momento</h2>
+        <p className="produtos__descricao">
+          Selecionamos lançamentos e clássicos Vans para completar sua
+          coleção. Escolha seu estilo favorito ou explore novas combinações.
+        </p>
+      </div>
 
-import './produtos.css'
+      <div className="produtos__grid">
+        {smallProducts.slice(0, 5).map((produto) => (
+          <ProdutosPequenos key={produto.id} {...produto} />
+        ))}
 
-export default function Produtos(){
-    return(
-        <div className='produtos'>
-            <h2>PRODUTOS</h2>
-            <div className='item-dos-produtos'>
-                <ProdutosPequenos identidade="sapato1" nome="sapatênis branco" valor="149.99"/>
-                <ProdutosPequenos identidade="sapato2" nome="sapato branco" valor="154.99"/>
-                <ProdutosPequenos identidade="sapato3" nome="sapato marrom claro" valor="130.00"/>
-                <ProdutosPequenos identidade="sapato4" nome="sapato marrom escuro" valor="140.00"/>
-                <ProdutosPequenos identidade="sapato5" nome="tênis azul acinzentado" valor="119.99"/>
-                <ProdutosGrandes/>
-                <ProdutosMedios nome={["NOVO","ESTILO","SKATES"]} identidade='skatista'/>
-                <ProdutosPequenos identidade="paisagem1" nome="acampamento no campo" valor="730.00"/>
-                <ProdutosPequenos identidade="paisagem2" nome="viagem para a praia no havaí" valor="2,300.00"/>
-                <ProdutosPequenos identidade="paisagem3" nome="trilha no campo e na floresta" valor="250.00"/>
-                <ProdutosMedios nome={["UNIFORME","AMIGAVEL","FASHION"]} identidade='sapato'/>
-            </div>
-        </div>
-    )
+        <ProdutosGrandes />
+
+        {mediumProducts.map((produto) => (
+          <ProdutosMedios key={produto.id} {...produto} />
+        ))}
+
+        {smallProducts.slice(5).map((produto) => (
+          <ProdutosPequenos key={produto.id} {...produto} />
+        ))}
+      </div>
+    </section>
+  );
 }

--- a/app/componentes/produtos/produtoGrande/ProdutosGrandes.jsx
+++ b/app/componentes/produtos/produtoGrande/ProdutosGrandes.jsx
@@ -1,49 +1,60 @@
-'use client'
-import { useState } from 'react'
-import '../produtoPequeno/produtospequenos.css'
-import ProdutosPequenos from '../produtoPequeno/ProdutosPequenos'
+"use client";
+
+import { useState } from "react";
+import ProdutosPequenos from "../produtoPequeno/ProdutosPequenos";
+import "./produtosgrandes.css";
+
+const shirts = [
+  { id: "camisa1", name: "Camisa GTA San Andreas", price: 70 },
+  { id: "camisa2", name: "Camisa Los Santos", price: 80 },
+  { id: "camisa3", name: "Camisa Grove Street", price: 75 },
+];
 
 export default function ProdutosGrandes() {
-    const camisas = [
-        { id: "camisa1", nome: "CAMISA GTA SAN ANDREAS", valor: "70.00" },
-        { id: "camisa2", nome: "CAMISA LOS SANTOS", valor: "80.00" },
-        { id: "camisa3", nome: "CAMISA GROVE STREET", valor: "75.00" },
-    ];
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const { id, name, price } = shirts[currentIndex];
 
-    const [indiceAtual, setIndiceAtual] = useState(0);
-    const passarCamisa = () => {
-        setIndiceAtual((prevIndice) => (prevIndice + 1) % camisas.length);
-    };
+  const handleNext = () => {
+    setCurrentIndex((index) => (index + 1) % shirts.length);
+  };
 
-    const voltarCamisa = () => {
-        setIndiceAtual((prevIndice) =>
-            (prevIndice - 1 + camisas.length) % camisas.length
-        );
-    };
+  const handlePrevious = () => {
+    setCurrentIndex((index) => (index - 1 + shirts.length) % shirts.length);
+  };
 
-    return (
-        <div className='produtos-grandes'>
-            <div className='produtos-grandes-dados'>
-                <p className='nome'>
-                    NOVOS <br />
-                    ESTILOS <br />
-                    E MAIS
-                </p>
-                <div className='linha'></div>
-                <button className='comprar'>COMPRAR</button>
-            </div>
+  return (
+    <article className="produto-destaque">
+      <div className="produto-destaque__conteudo">
+        <h3 className="produto-destaque__titulo">
+          Novos <br /> Estilos <br /> e mais
+        </h3>
+        <span className="produto-destaque__linha" aria-hidden="true" />
+        <button type="button" className="produto-destaque__cta">
+          Comprar
+        </button>
+      </div>
 
-            <div className='itens'>
-                <button id='volta' onClick={voltarCamisa}>‹</button>
-                <div className='item'>
-                    <ProdutosPequenos
-                        identidade={camisas[indiceAtual].id}
-                        nome={camisas[indiceAtual].nome}
-                        valor={camisas[indiceAtual].valor}
-                    />
-                </div>
-                <button id='passa' onClick={passarCamisa}>›</button>
-            </div>
-        </div>
-    );
+      <div className="produto-destaque__carousel" aria-live="polite">
+        <button
+          type="button"
+          className="produto-destaque__controle"
+          onClick={handlePrevious}
+          aria-label="Ver produto anterior"
+        >
+          ‹
+        </button>
+
+        <ProdutosPequenos id={id} name={name} price={price} />
+
+        <button
+          type="button"
+          className="produto-destaque__controle"
+          onClick={handleNext}
+          aria-label="Ver próximo produto"
+        >
+          ›
+        </button>
+      </div>
+    </article>
+  );
 }

--- a/app/componentes/produtos/produtoGrande/produtosgrandes.css
+++ b/app/componentes/produtos/produtoGrande/produtosgrandes.css
@@ -1,153 +1,119 @@
-.produtos-grandes {
-    min-width: 360px;
-    height: 250px;
-    box-sizing: border-box;
-    margin: 10px;
-    display: flex;
-    justify-content: space-around;
-    flex-grow: 1;
+.produto-destaque {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: center;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  border-radius: var(--raio-borda-grande);
+  background: linear-gradient(135deg, #0a0a0a, #2c0f12 60%, #530611);
+  color: #ffffff;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.2);
 }
 
-.itens {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.produto-destaque__conteudo {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-#volta, #passa {
-    display: block;
-    width: 30px;
-    height: 30px;
+.produto-destaque__titulo {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  line-height: 1.2;
+}
+
+.produto-destaque__linha {
+  width: 50px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.produto-destaque__cta {
+  align-self: flex-start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: #ffffff;
+  color: #0a0a0a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform var(--duracao-transicao) ease,
+    background var(--duracao-transicao) ease,
+    color var(--duracao-transicao) ease;
+}
+
+.produto-destaque__cta:hover,
+.produto-destaque__cta:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.produto-destaque__carousel {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.produto-destaque__controle {
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: background var(--duracao-transicao) ease,
+    transform var(--duracao-transicao) ease;
+}
+
+.produto-destaque__controle:hover,
+.produto-destaque__controle:focus-visible {
+  background: rgba(255, 255, 255, 0.35);
+  transform: translateY(-2px);
+}
+
+.produto-destaque .produto-pequeno {
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+  color: #ffffff;
+}
+
+.produto-destaque .produto-pequeno__nome,
+.produto-destaque .produto-pequeno__valor {
+  color: #ffffff;
+}
+
+.produto-destaque .produto-pequeno__separador {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+@media (max-width: 900px) {
+  .produto-destaque {
+    grid-template-columns: 1fr;
     text-align: center;
-    color: darkgray;
-    background-color: brown;
-    border: none;
-    cursor: pointer;
-}
+  }
 
-#volta:hover, #passa:hover {
-    background-color: darkred;
-    color: white;
-}
+  .produto-destaque__conteudo {
+    align-items: center;
+  }
 
-.produtos-grandes .itens .item > * {
-    display: none;
-    box-shadow: none;
-    transition: transform 0.3s ease-in-out;
-}
+  .produto-destaque__cta {
+    align-self: center;
+  }
 
-.produtos-grandes .itens .item > *:first-child {
-    display: flex;
-    margin: 0;
-}
+  .produto-destaque__carousel {
+    grid-template-columns: 1fr;
+  }
 
-
-.produtos-grandes .itens .item:hover > *:first-child {
-    transform: scale(1.1);
-}
-
-.produtos-grandes .produtos-grandes-dados .nome {
-    font-weight: bold;
-    font-size: 150%;
-    margin-left: 20px;
-    margin-top: 40px;
-}
-
-.produtos-grandes .produtos-grandes-dados .linha {
-    width: 40px;
-    border-top: 1px solid black;
-    margin: 20px 0;
-    margin-left: 20px;
-}
-
-.produtos-grandes .produtos-grandes-dados .comprar {
-    color: white;
-    background-color: darkred;
-    margin-left: 20px;
-    padding: 10px 5px;
-    border: none;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-}
-
-.produtos-grandes .produtos-grandes-dados .comprar:hover {
-    background-color: crimson;
-}
-
-@media (max-width: 768px) {
-    .produtos-grandes {
-        min-width: 200px;
-        height: 100px;
-        box-sizing: border-box;
-        margin: 10px;
-        display: flex;
-        justify-content: space-around;
-        flex-grow: 1;
-    }
-    
-    .itens {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    
-    #volta, #passa {
-        display: block;
-        width: 15px;
-        height: 15px;
-        text-align: center;
-        color: darkgray;
-        background-color: brown;
-        border: none;
-        cursor: pointer;
-    }
-    
-    #volta:hover, #passa:hover {
-        background-color: darkred;
-        color: white;
-    }
-    
-    .produtos-grandes .itens .item > * {
-        display: none;
-        box-shadow: none;
-        transition: transform 0.3s ease-in-out;
-    }
-    
-    .produtos-grandes .itens .item > *:first-child {
-        display: flex;
-        margin: 0;
-    }
-    
-    
-    .produtos-grandes .itens .item:hover > *:first-child {
-        transform: scale(1.1);
-    }
-    
-    .produtos-grandes .produtos-grandes-dados .nome {
-        font-weight: bold;
-        font-size: 75%;
-        margin-left: 10px;
-        margin-top: 20px;
-    }
-    
-    .produtos-grandes .produtos-grandes-dados .linha {
-        width: 20px;
-        border-top: 1px solid black;
-        margin: 10px 0;
-        margin-left: 10px;
-    }
-    
-    .produtos-grandes .produtos-grandes-dados .comprar {
-        color: white;
-        background-color: darkred;
-        margin-left: 20px;
-        padding: 10px 5px;
-        border: none;
-        cursor: pointer;
-        transition: background-color 0.3s ease;
-    }
-    
-    .produtos-grandes .produtos-grandes-dados .comprar:hover {
-        background-color: crimson;
-    }
+  .produto-destaque__controle {
+    justify-self: center;
+    width: 36px;
+    height: 36px;
+  }
 }

--- a/app/componentes/produtos/produtoMedio/ProdutosMedios.jsx
+++ b/app/componentes/produtos/produtoMedio/ProdutosMedios.jsx
@@ -1,17 +1,22 @@
-
-export default function ProdutosMedios({nome, identidade}){
-    return(<>
-        <div className='produtos-medios'>
-            <div className='produtos-medios-dados'>
-                <p className='nome'>
-                    {nome[0]} <br/>
-                    {nome[1]} <br/>
-                    {nome[2]}
-                </p>
-                <div className='linha'></div>
-                <button className='comprar'>COMPRAR</button>
-            </div>
-            <div className='imagem' id={identidade}></div>    
-        </div>
-    </>)
+export default function ProdutosMedios({ highlights, id }) {
+  return (
+    <article className="produto-medio" aria-labelledby={`${id}-destaque`}>
+      <div className="produto-medio__conteudo">
+        <h3 id={`${id}-destaque`} className="produto-medio__titulo">
+          {highlights.map((texto) => (
+            <span key={texto}>{texto}</span>
+          ))}
+        </h3>
+        <span className="produto-medio__linha" aria-hidden="true" />
+        <button type="button" className="produto-medio__cta">
+          Comprar
+        </button>
+      </div>
+      <div
+        className={`produto-medio__imagem produto-medio__imagem--${id}`}
+        role="presentation"
+        aria-hidden="true"
+      />
+    </article>
+  );
 }

--- a/app/componentes/produtos/produtoMedio/produtosmedios.css
+++ b/app/componentes/produtos/produtoMedio/produtosmedios.css
@@ -1,55 +1,95 @@
-.produtos-medios {
-    width: 380px;
-    height: 250px;
-    box-sizing: border-box;
-    margin: 10px;
-    padding: 30px;
-    display: flex;
-    justify-content: space-around;
-    flex-grow: 1;
-    transition: transform 0.3s ease-in-out; /* Adiciona transição suave */
-    cursor: pointer; /* Adiciona cursor de mão */
+.produto-medio {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: var(--raio-borda-grande);
+  background: linear-gradient(135deg, #ffffff 0%, #f2f2f2 100%);
+  box-shadow: 0 20px 45px rgba(10, 10, 10, 0.1);
+  align-items: center;
+  transition: transform var(--duracao-transicao) ease,
+    box-shadow var(--duracao-transicao) ease;
 }
 
-.produtos-medios:hover {
-    transform: scale(1.1); /* Aumenta o item em 10% */
+.produto-medio:hover,
+.produto-medio:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 55px rgba(10, 10, 10, 0.15);
 }
 
-.produtos-medios .imagem {
-    min-width: 160px;
-    min-height: calc(100% - 60px); /* Corrige o cálculo do tamanho */
-    background-color: lightgray;
-    transition: transform 0.3s ease-in-out; /* Adiciona transição suave */
+.produto-medio__conteudo {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.produtos-medios .imagem:hover {
-    transform: scale(1.1); /* Aumenta a imagem em 10% */
+.produto-medio__titulo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--cor-texto);
 }
 
-.produtos-medios .produtos-medios-dados .nome {
-    font-weight: bold;
-    font-size: 150%;
-    margin-top: 10px;
+.produto-medio__linha {
+  width: 50px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--cor-acento);
 }
 
-.produtos-medios .produtos-medios-dados .linha {
-    width: 40px;
-    border-top: 1px solid black;
-    margin: 20px 0;
+.produto-medio__cta {
+  align-self: flex-start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--cor-acento);
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background var(--duracao-transicao) ease,
+    transform var(--duracao-transicao) ease;
 }
 
-.produtos-medios .produtos-medios-dados .comprar {
-    color: white;
-    background-color: darkred;
-    padding: 10px;
-    border: none;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
+.produto-medio__cta:hover,
+.produto-medio__cta:focus-visible {
+  background: var(--cor-acento-escuro);
+  transform: translateY(-2px);
 }
 
-.produtos-medios .produtos-medios-dados .comprar:hover {
-    background-color: crimson;
+.produto-medio__imagem {
+  width: 100%;
+  min-height: 220px;
+  border-radius: 1.25rem;
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: #f7f7f7;
 }
 
-#sapato { background: url("./imagens/sapato.jpg") no-repeat center / contain; }
-#skatista { background: url("./imagens/skatista.jpg") no-repeat center / contain; }
+.produto-medio__imagem--sapato {
+  background-image: url("./imagens/sapato.jpg");
+}
+
+.produto-medio__imagem--skatista {
+  background-image: url("./imagens/skatista.jpg");
+}
+
+@media (max-width: 768px) {
+  .produto-medio {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .produto-medio__conteudo {
+    align-items: center;
+  }
+
+  .produto-medio__cta {
+    align-self: center;
+  }
+}

--- a/app/componentes/produtos/produtoPequeno/ProdutosPequenos.jsx
+++ b/app/componentes/produtos/produtoPequeno/ProdutosPequenos.jsx
@@ -1,11 +1,22 @@
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  maximumFractionDigits: 2,
+});
 
-export default function ProdutosPequenos({identidade, nome, valor, indentidadeItem}){
-    return(<>
-        <div className='produtos-pequenos' id={indentidadeItem}>
-            <div className='imagem' id={identidade}></div>
-            <div className='nome'>{nome}</div>
-            <div className='linha'></div>
-            <div className='valor'>R${valor}</div>
-        </div>
-    </>)
+export default function ProdutosPequenos({ id, name, price }) {
+  return (
+    <article className="produto-pequeno" aria-labelledby={`${id}-titulo`}>
+      <div
+        className={`produto-pequeno__imagem produto-pequeno__imagem--${id}`}
+        role="presentation"
+        aria-hidden="true"
+      />
+      <h3 id={`${id}-titulo`} className="produto-pequeno__nome">
+        {name}
+      </h3>
+      <span className="produto-pequeno__separador" aria-hidden="true" />
+      <p className="produto-pequeno__valor">{currencyFormatter.format(price)}</p>
+    </article>
+  );
 }

--- a/app/componentes/produtos/produtoPequeno/produtospequenos.css
+++ b/app/componentes/produtos/produtoPequeno/produtospequenos.css
@@ -1,58 +1,99 @@
-.produtos-pequenos {
-    width: 180px;
-    height: 250px;
-    box-sizing: border-box;
-    margin: 10px;
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    flex-grow: 1;
-    transition: transform 0.3s ease-in-out;
-    cursor: pointer;
+.produto-pequeno {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border-radius: 1.5rem;
+  background: var(--cor-superficie);
+  box-shadow: 0 18px 45px rgba(10, 10, 10, 0.08);
+  text-align: center;
+  transition: transform var(--duracao-transicao) ease,
+    box-shadow var(--duracao-transicao) ease;
 }
 
-.produtos-pequenos:hover {
-    transform: scale(1.1);
+.produto-pequeno:hover,
+.produto-pequeno:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 60px rgba(10, 10, 10, 0.12);
 }
 
-.produtos-pequenos .imagem {
-    width: 100px;
-    aspect-ratio: 1;
-    background-color: lightgray;
-    transition: transform 0.3s ease-in-out; /* Adiciona transição suave */
+.produto-pequeno__imagem {
+  width: clamp(120px, 35vw, 160px);
+  aspect-ratio: 1;
+  border-radius: 1rem;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
-.produtos-pequenos .imagem:hover {
-    transform: scale(1.1); /* Aumenta a imagem em 10% */
+.produto-pequeno__nome {
+  font-size: 1rem;
+  text-transform: capitalize;
+  color: var(--cor-texto);
 }
 
-.produtos-pequenos .nome {
-    color: black;
-    font-weight: bold;
-    text-align: center;
-    margin-top: 10px;
+.produto-pequeno__separador {
+  width: 32px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.15);
 }
 
-.produtos-pequenos .linha {
-    width: 20px;
-    border-top: 1px solid black;
-    margin: 10px;
+.produto-pequeno__valor {
+  font-weight: 700;
+  color: var(--cor-acento);
 }
 
-.produtos-pequenos .valor {
-    color: red;
+.produto-pequeno__imagem--sapato1 {
+  background-image: url("./imagens/sapato1.jpg");
 }
 
-#sapato1 { background: url("./imagens/sapato1.jpg") no-repeat center / cover; }
-#sapato2 { background: url("./imagens/sapato2.jpg") no-repeat center / cover; }
-#sapato3 { background: url("./imagens/sapato3.jpg") no-repeat center / contain; }
-#sapato4 { background: url("./imagens/sapato4.jpg") no-repeat center / cover; }
-#sapato5 { background: url("./imagens/sapato5.jpg") no-repeat center / cover; }
-#paisagem1 { background: url("./imagens/paisagem1.jpg") no-repeat center / cover; }
-#paisagem2 { background: url("./imagens/paisagem2.jpg") no-repeat center / cover; }
-#paisagem3 { background: url("./imagens/paisagem3.jpg") no-repeat center / cover; }
-#camisa1 { background: url("./imagens/camisa1.jpg") no-repeat center / cover; }
-#camisa2 { background: url("./imagens/camisa2.jpg") no-repeat center / cover; }
-#camisa3 { background: url("./imagens/camisa3.jpg") no-repeat center / cover; }
+.produto-pequeno__imagem--sapato2 {
+  background-image: url("./imagens/sapato2.jpg");
+}
+
+.produto-pequeno__imagem--sapato3 {
+  background-image: url("./imagens/sapato3.jpg");
+  background-size: contain;
+  background-color: #f3f3f3;
+}
+
+.produto-pequeno__imagem--sapato4 {
+  background-image: url("./imagens/sapato4.jpg");
+}
+
+.produto-pequeno__imagem--sapato5 {
+  background-image: url("./imagens/sapato5.jpg");
+}
+
+.produto-pequeno__imagem--paisagem1 {
+  background-image: url("./imagens/paisagem1.jpg");
+}
+
+.produto-pequeno__imagem--paisagem2 {
+  background-image: url("./imagens/paisagem2.jpg");
+}
+
+.produto-pequeno__imagem--paisagem3 {
+  background-image: url("./imagens/paisagem3.jpg");
+}
+
+.produto-pequeno__imagem--camisa1 {
+  background-image: url("./imagens/camisa1.jpg");
+}
+
+.produto-pequeno__imagem--camisa2 {
+  background-image: url("./imagens/camisa2.jpg");
+}
+
+.produto-pequeno__imagem--camisa3 {
+  background-image: url("./imagens/camisa3.jpg");
+}
+
+@media (max-width: 768px) {
+  .produto-pequeno {
+    padding: 1.25rem 1rem;
+    gap: 0.75rem;
+  }
+}

--- a/app/componentes/produtos/produtos.css
+++ b/app/componentes/produtos/produtos.css
@@ -1,26 +1,56 @@
-
 .produtos {
-    width: 100%;
-    margin-bottom: 20px;
+  width: min(1200px, 100%);
+  margin: clamp(3rem, 6vw, 5rem) auto;
+  padding: 0 clamp(1.5rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
-.produtos h2 {
-    width: 100%;
-    margin: 20px 0;
-    text-align: center;
-    font-size: 200%;
+.produtos__cabecalho {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.produtos .item-dos-produtos {
-    width: 100%;
-    
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    align-items: center;
+.produtos__etiqueta {
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--cor-acento);
+  font-weight: 700;
+}
+
+.produtos__titulo {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: var(--cor-texto);
+}
+
+.produtos__descricao {
+  color: var(--cor-texto-suave);
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+.produtos__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.25rem, 4vw, 2rem);
+  align-items: stretch;
 }
 
 @media (max-width: 768px) {
-    
+  .produtos {
+    margin: 3rem auto;
+    gap: 2rem;
+  }
+
+  .produtos__cabecalho {
+    text-align: left;
+  }
+
+  .produtos__descricao {
+    margin: 0;
+  }
 }

--- a/app/componentes/rodape/RodaPe.jsx
+++ b/app/componentes/rodape/RodaPe.jsx
@@ -1,45 +1,125 @@
-'use client';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faList, faFire, faMale, faFemale, faChild, faHeadset, faPhone, faCreditCard, faBox, faEnvelope, faPaperPlane } from '@fortawesome/free-solid-svg-icons';
-import { faFacebook, faTwitter, faInstagram, faYoutube } from '@fortawesome/free-brands-svg-icons';
-import './rodape.css';
+"use client";
+
+import { useMemo, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faBox,
+  faChild,
+  faCreditCard,
+  faEnvelope,
+  faFire,
+  faHeadset,
+  faList,
+  faMale,
+  faPhone,
+  faFemale,
+} from "@fortawesome/free-solid-svg-icons";
+import {
+  faFacebook,
+  faInstagram,
+  faTwitter,
+  faYoutube,
+} from "@fortawesome/free-brands-svg-icons";
+import "./rodape.css";
 
 export default function RodaPe() {
-    function handler() {
-        alert("Email " + document.getElementById("email").value + " Adicionado com sucesso");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const categories = useMemo(
+    () => [
+      {
+        icon: faList,
+        title: "Categorias",
+        links: [
+          { icon: faFire, label: "Novidades" },
+          { icon: faMale, label: "Masculino" },
+          { icon: faFemale, label: "Feminino" },
+          { icon: faChild, label: "Infantil" },
+        ],
+      },
+      {
+        icon: faHeadset,
+        title: "Suporte",
+        links: [
+          { icon: faPhone, label: "Atendimento" },
+          { icon: faCreditCard, label: "Pagamento" },
+          { icon: faBox, label: "Pedidos" },
+        ],
+      },
+      {
+        icon: faEnvelope,
+        title: "Contatos",
+        links: [
+          { icon: faFacebook, label: "Facebook" },
+          { icon: faTwitter, label: "Twitter" },
+          { icon: faInstagram, label: "Instagram" },
+          { icon: faYoutube, label: "YouTube" },
+        ],
+      },
+    ],
+    []
+  );
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!email.trim()) {
+      setMessage("Digite um e-mail válido para se inscrever.");
+      return;
     }
 
-    return (
-        <div className="rodape">
-            <div className="categorias">
-                <p><FontAwesomeIcon icon={faList} /> Categorias</p>
-                <a href="#"><FontAwesomeIcon icon={faFire} /> Novidades</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faMale} /> Masculino</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faFemale} /> Feminino</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faChild} /> Infantil</a>
-            </div>
+    setMessage(`E-mail ${email} cadastrado com sucesso!`);
+    setEmail("");
+  };
 
-            <div className="categorias">
-                <p><FontAwesomeIcon icon={faHeadset} /> Suporte</p>
-                <a href="#"><FontAwesomeIcon icon={faPhone} /> Atendimento</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faCreditCard} /> Pagamento</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faBox} /> Pedidos</a> <br />
-            </div>
+  return (
+    <footer className="rodape">
+      <div className="rodape__conteudo">
+        {categories.map(({ icon, title, links }) => (
+          <div key={title} className="rodape__coluna">
+            <p className="rodape__titulo">
+              <FontAwesomeIcon icon={icon} /> {title}
+            </p>
+            <ul className="rodape__lista">
+              {links.map(({ icon: linkIcon, label }) => (
+                <li key={label}>
+                  <a href="#">
+                    <FontAwesomeIcon icon={linkIcon} /> {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
 
-            <div className="categorias">
-                <p><FontAwesomeIcon icon={faEnvelope} /> Contatos</p>
-                <a href="#"><FontAwesomeIcon icon={faFacebook} /> Facebook</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faTwitter} /> Twitter</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faInstagram} /> Instagram</a> <br />
-                <a href="#"><FontAwesomeIcon icon={faYoutube} /> YouTube</a>
-            </div>
-
-            <div className="categorias">
-                <p><FontAwesomeIcon icon={faEnvelope} /> Inscreva-se</p>
-                <span>Receba notícias em seu e-mail.</span> <br />
-                <input id="email" placeholder="Digite o seu email" />
-                <button onClick={handler}><FontAwesomeIcon icon={faPaperPlane} /> Enviar</button>
-            </div>
+        <div className="rodape__coluna rodape__coluna--formulario">
+          <p className="rodape__titulo">
+            <FontAwesomeIcon icon={faEnvelope} /> Inscreva-se
+          </p>
+          <p className="rodape__texto">
+            Receba as novidades, lançamentos e promoções direto no seu e-mail.
+          </p>
+          <form className="rodape__formulario" onSubmit={handleSubmit}>
+            <label htmlFor="newsletter-email" className="sr-only">
+              Digite o seu e-mail
+            </label>
+            <input
+              id="newsletter-email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="Digite o seu e-mail"
+              required
+            />
+            <button type="submit">Inscrever</button>
+          </form>
+          {message && <span className="rodape__mensagem">{message}</span>}
         </div>
-    );
+      </div>
+
+      <div className="rodape__base">
+        <p>© {new Date().getFullYear()} Vans. Todos os direitos reservados.</p>
+      </div>
+    </footer>
+  );
 }

--- a/app/componentes/rodape/rodape.css
+++ b/app/componentes/rodape/rodape.css
@@ -1,114 +1,120 @@
-
 .rodape {
-    min-width: 400px;
-    box-sizing: border-box;
-    padding: 50px 10px;
-    background-color: #202124;
-    display: flex;
-    justify-content: space-around;
+  background: var(--cor-superficie-escura);
+  color: rgba(255, 255, 255, 0.88);
+  padding: clamp(3rem, 6vw, 4rem) clamp(1.5rem, 5vw, 4rem);
 }
 
-.rodape .categorias {
-    width: 160px;
+.rodape__conteudo {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
-.rodape .categorias * {
-    color: lightgray;
-    font-family: Arial, Helvetica, sans-serif;
+.rodape__coluna {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.rodape .categorias p {
-    padding: 10px 0;
-    font-size: 120%;
-    color: white;
+.rodape__titulo {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.rodape .categorias a {
-    margin: 7px 0;
-    display: inline-block;
-    text-decoration: none;
-    transition: 500ms;
-}
-.rodape .categorias a:hover {
-    color: #b92f35;
+.rodape__lista {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
 }
 
-.rodape .categorias span {
-    margin: 10px 0;
-    display: inline-block;
+.rodape__lista a {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  transition: color var(--duracao-transicao) ease;
 }
 
-.rodape .categorias input {
-    width: 110px;
-    height: 40px;
-    margin: 10px 0;
-    border: 1px solid lightgray;
-    background-color: #202124;
+.rodape__lista a:hover,
+.rodape__lista a:focus-visible {
+  color: #ffffff;
 }
 
-.rodape .categorias button {
-    width: 60%;
-    height: 15%;
-    aspect-ratio: 1;
-    text-align: center;
-    background-color: #b92f35;
+.rodape__coluna--formulario {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  gap: 1rem;
+}
+
+.rodape__texto {
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.6;
+}
+
+.rodape__formulario {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.rodape__formulario input {
+  flex: 1 1 200px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+.rodape__formulario input::placeholder {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.rodape__formulario button {
+  flex: 0 0 auto;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--cor-acento);
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: background var(--duracao-transicao) ease,
+    transform var(--duracao-transicao) ease;
+}
+
+.rodape__formulario button:hover,
+.rodape__formulario button:focus-visible {
+  background: var(--cor-acento-escuro);
+  transform: translateY(-2px);
+}
+
+.rodape__mensagem {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.rodape__base {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
 }
 
 @media (max-width: 768px) {
-    
-.rodape {
-    min-width: 400px;
-    box-sizing: border-box;
-    padding: 50px 10px;
-    background-color: #202124;
-    display: flex;
-    justify-content: space-around;
-    flex-wrap: wrap;
-}
+  .rodape__formulario {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.rodape .categorias {
-    width: 160px;
-}
-
-.rodape .categorias * {
-    color: lightgray;
-    font-family: Arial, Helvetica, sans-serif;
-}
-
-.rodape .categorias p {
-    padding: 10px 0;
-    font-size: 120%;
-    color: white;
-}
-
-.rodape .categorias a {
-    margin: 7px 0;
-    display: inline-block;
-    text-decoration: none;
-    transition: 500ms;
-}
-.rodape .categorias a:hover {
-    color: #b92f35;
-}
-
-.rodape .categorias span {
-    margin: 10px 0;
-    display: inline-block;
-}
-
-.rodape .categorias input {
-    width: 110px;
-    height: 40px;
-    margin: 10px 0;
-    border: 1px solid lightgray;
-    background-color: #202124;
-}
-
-.rodape .categorias button {
-    width: 60%;
-    height: 15%;
-    aspect-ratio: 1;
-    text-align: center;
-    background-color: #b92f35;
-}
+  .rodape__formulario button {
+    width: 100%;
+  }
 }

--- a/app/componentes/vans/Vans.jsx
+++ b/app/componentes/vans/Vans.jsx
@@ -1,15 +1,14 @@
-
 import InicioVans from "../InicioVans/InicioVans";
 import Produtos from "../produtos/Produtos";
 import RodaPe from "../rodape/RodaPe";
-import "./vans.css"
+import "./vans.css";
 
-export default function Vans(){
-    return(
-        <div className="vans">
-            <InicioVans/>
-            <Produtos/>
-            <RodaPe/>
-        </div>
-    )
+export default function VansLanding() {
+  return (
+    <main className="vans">
+      <InicioVans />
+      <Produtos />
+      <RodaPe />
+    </main>
+  );
 }

--- a/app/componentes/vans/vans.css
+++ b/app/componentes/vans/vans.css
@@ -1,26 +1,8 @@
-/* Zerar margens e padding globais */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-html, body {
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    height: 100%;
-}
-
 .vans {
-    min-width: 400px;
-    width: 100vw;
-    height: 100vh;
-    overflow-y: scroll;
-    overflow-x: hidden;
-    scrollbar-width: none;
-}
-
-.vans::-webkit-scrollbar {
-    display: none;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  width: 100%;
+  background-color: var(--cor-fundo, #f5f6f7);
+  color: var(--cor-texto, #111);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,52 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", Roboto, -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", Arial, sans-serif;
+  --cor-fundo: #f5f6f7;
+  --cor-texto: #111111;
+  --cor-texto-suave: #444444;
+  --cor-acento: #c41230;
+  --cor-acento-escuro: #780d1e;
+  --cor-superficie: #ffffff;
+  --cor-superficie-escura: #202124;
+  --raio-borda-grande: 1.5rem;
+  --duracao-transicao: 200ms;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  margin: 0;
+  background-color: var(--cor-fundo);
+  color: var(--cor-texto);
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+}
+
+img,
+svg {
+  display: block;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,9 +1,5 @@
-import RepGame from "./componentes/vans/Vans";
+import VansLanding from "./componentes/vans/Vans";
 
 export default function Home() {
-  return (
-    <>
-      <RepGame />
-    </>
-  );
+  return <VansLanding />;
 }


### PR DESCRIPTION
## Summary
- add global design tokens and clean layout structure for the Vans landing page wrapper
- rebuild the hero header with a responsive navigation bar, refreshed copy and CTA styling
- reorganise product highlights with reusable data-driven cards, carousel controls and updated styles
- redesign the footer with mapped icon sections, a validated newsletter form and refreshed visuals
- add a baseline Next.js ESLint configuration to keep linting non-interactive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e5cdab4590832492ad962406847bdb